### PR TITLE
Empty block once an hour instead of every second

### DIFF
--- a/atlas/gaia/config.toml
+++ b/atlas/gaia/config.toml
@@ -14,7 +14,7 @@ laddr = "tcp://0.0.0.0:46657"
 
 
 [consensus]
-create_empty_blocks_interval = 1
+create_empty_blocks_interval = 3600
 
 
 [p2p]


### PR DESCRIPTION
At least for testing, it seems a bit excessive to wait for 100.000s of empty blocks to sync.